### PR TITLE
docs: add post-merge checklist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,3 +7,8 @@
 - When on `main` and making changes, create a new branch for the work (branch protection requires PRs).
 - Write clear, concise PR descriptions summarizing changes and tests.
 - After every commit, review and update the PR description (and title if needed) so it matches the latest changes.
+
+### Post-merge required steps
+- `git checkout main`
+- `git pull`
+- Only then start new work or branch


### PR DESCRIPTION
## Summary
- add a post-merge checklist to copilot instructions (checkout main, pull, then branch)

## Testing
- not run (docs only)
