### PR TITLE
fix: address code review findings

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -2,9 +2,12 @@
 
 - **brainstorming** — Use before any creative work to clarify intent and design before implementation.
 - **dispatching-parallel-agents** — Use when 2+ independent tasks can run in parallel without shared state.
+- **github-actions** — Use when creating or optimizing GitHub Actions for CI/CD pipelines.
 - **github-copilot** — Use to consult other AI models via GitHub Copilot CLI for second opinions or deep analysis.
+- **github-workflows** — Use when writing and configuring GitHub Actions workflow files.
 - **requesting-code-review** — Use after tasks/major features or pre-merge to dispatch the `code-reviewer` agent.
 - **rust-developer** — Use for Rust coding/review/debugging guidance and best practices.
+- **rust-language** — Use for Rust language fundamentals: ownership, borrowing, lifetimes, async, and best practices.
 - **subagent-driven-development** — Use to execute implementation plans in-session with per-task subagents and two-stage reviews.
 - **using-git-worktrees** — Use to create isolated git worktrees safely before starting feature work.
 - **writing-skills** — Use when creating/editing skills with a test-driven documentation approach.

--- a/.claude/skills/rust-developer/SKILL.md
+++ b/.claude/skills/rust-developer/SKILL.md
@@ -316,17 +316,19 @@ When reviewing Rust PRs, check against:
 
 ---
 
-## Catalyst-Specific Patterns
+## Example Project Patterns
 
-### Project Structure
+> **Note:** The following patterns are examples from a real project. Adapt them to your own project structure.
+
+### Project Structure Example
 
 ```
-catalyst/
-├── catalyst-core/         # Core library (shared logic)
+my-project/
+├── my-project-core/       # Core library (shared logic)
 │   ├── src/
 │   │   └── lib.rs
 │   └── Cargo.toml
-└── catalyst-cli/          # CLI binaries (hooks, tools)
+└── my-project-cli/        # CLI binaries (hooks, tools)
     ├── src/bin/
     │   ├── file_analyzer.rs
     │   ├── skill_activation_prompt.rs
@@ -334,7 +336,7 @@ catalyst/
     └── Cargo.toml
 ```
 
-### Common Patterns in This Project
+### Common Patterns
 
 **Binary Structure:**
 ```rust
@@ -392,11 +394,9 @@ error!(
 
 ---
 
-## Integration with Catalyst Workflow
+## When to Use This Skill
 
-### When This Skill Activates
-
-This skill automatically activates when:
+This skill is useful when:
 
 1. **File Triggers:**
    - Editing any `.rs` file in the project
@@ -413,13 +413,6 @@ This skill automatically activates when:
    - Code contains Rust-specific patterns (Result, Option, impl, trait)
    - Working with thiserror, anyhow, serde
    - Using Rust ecosystem crates
-
-### Complementary Skills
-
-This skill works well with:
-
-- **skill-developer** - When creating new skills in Rust
-- **error-tracking** - When integrating Sentry (though we don't use it for Rust yet)
 
 ---
 

--- a/docs/rust-lessons/index.md
+++ b/docs/rust-lessons/index.md
@@ -237,12 +237,4 @@ This guide consolidates related topics that were previously scattered:
 
 ---
 
-## 🔗 Related Documentation
-
-- **[PowerShell Lessons Learned](../powershell-lessons.md)** - Best practices for PowerShell script development
-- **[Performance Comparison](../performance-comparison.md)** - Rust vs interpreted languages
-- **[Standalone Installation](../standalone-installation.md)** - Cross-platform setup guide
-
----
-
 **Ready to learn?** Start with the [Quick Reference Checklist →](quick-reference.md)


### PR DESCRIPTION
## Summary

- Add missing skills to index (github-actions, github-workflows, rust-language)
- Remove dead links to non-existent docs in rust-lessons/index.md
- Genericize project-specific patterns in rust-developer skill

## Test plan

- [x] Verified skills index now lists all 11 skills
- [x] Confirmed dead links removed from rust-lessons/index.md
- [x] Checked rust-developer skill uses generic example naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)