### PR TITLE
fix: add reference to orphaned sources.md in rust-language skill

### DIFF
--- a/.claude/skills/rust-language/SKILL.md
+++ b/.claude/skills/rust-language/SKILL.md
@@ -981,3 +981,9 @@ let speed = calculate_speed(Meters(100.0), Seconds(9.8));
 - **Use the type system**: Let the compiler catch errors
 - **Test thoroughly**: Tests are first-class in Rust
 - **Use clippy**: Catch common mistakes and non-idiomatic code
+
+---
+
+## Sources
+
+See [sources.md](sources.md) for documentation references used to create this skill.


### PR DESCRIPTION
## Summary

- Add Sources section to rust-language/SKILL.md linking to sources.md
- Fixes orphaned file identified in code review

## Test plan

- [x] Verified link is correct relative path
- [x] Confirmed sources.md contains valid attribution info

🤖 Generated with [Claude Code](https://claude.com/claude-code)