### PR TITLE
fix: align PLAN_REFERENCE placeholder with code-reviewer template

### DIFF
--- a/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -11,7 +11,7 @@ Task tool (superpowers:code-reviewer):
   Use template at requesting-code-review/code-reviewer.md
 
   WHAT_WAS_IMPLEMENTED: [from implementer's report]
-  PLAN_OR_REQUIREMENTS: Task N from [plan-file]
+  PLAN_REFERENCE: Task N from [plan-file]
   BASE_SHA: [commit before task]
   HEAD_SHA: [current commit]
   DESCRIPTION: [task summary]

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,49 @@
+# Known Issues
+
+Issues identified during code review (2026-01-02).
+
+## High
+
+*No open issues.*
+
+---
+
+## Medium
+
+### Broken deep-dive anchor links in quick-reference
+
+**Location:** `docs/rust-lessons/quick-reference.md` (lines 229, 257, 283, 307, 369, 398, 523, 552)
+
+**Description:** Multiple deep-dive links point to anchors that don't exist:
+- `performance-deep-dive.md#loop-optimizations` → should be `#1-performance-critical-loop-optimizations`
+- `performance-deep-dive.md#zero-copy` → should be `#2-when-not-to-use-zero-copy-abstractions`
+- `file-io-deep-dive.md#atomic-writes` → should be `#1-atomic-file-writes`
+- `file-io-deep-dive.md#parent-directories` → should be `#2-parent-directories-for-file-writes`
+- `file-io-deep-dive.md#testing` → should be `#4-testing-file-io`
+- `type-safety-deep-dive.md#constants` → should be `#2-using-constants-for-validation`
+- `common-footguns.md#borrow-checker` → should be `#3-borrow-checker-with-hashset`
+- `common-footguns.md#toctou-races` → should be `#4-fixing-toctou-races`
+
+**Fix:** Update links to match actual numbered heading anchors.
+
+---
+
+### Overly permissive default flags in github-copilot skill
+
+**Location:** `.claude/skills/github-copilot/SKILL.md:37-48`
+
+**Description:** Default invocation recommends `--allow-all-paths --allow-all-tools` for every copilot call, granting unnecessary filesystem/tool access for simple second-opinion queries.
+
+**Fix:** Default to least privilege (omit flags unless required) and document when elevated access is needed.
+
+---
+
+## Low
+
+### Lesson count mismatch
+
+**Location:** `docs/rust-lessons/index.md:21-22` vs `docs/rust-lessons/quick-reference.md:12`
+
+**Description:** Index claims quick reference has 20 lessons, but quick-reference lists 21.
+
+**Fix:** Reconcile the counts or remove hard-coded numbers.


### PR DESCRIPTION
## Summary

- Fix placeholder mismatch: `PLAN_OR_REQUIREMENTS` → `PLAN_REFERENCE` in code-quality-reviewer-prompt.md
- Add ISSUES.md tracking remaining code review findings

## Test plan

- [x] Verified placeholder now matches template in requesting-code-review/code-reviewer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)