### PR TITLE
fix: address medium priority issues from code review

### DIFF
--- a/.claude/skills/github-copilot/SKILL.md
+++ b/.claude/skills/github-copilot/SKILL.md
@@ -37,14 +37,19 @@ Note: Copilot may take longer to respond. Use appropriate timeout values (up to 
 Execute copilot in the current working directory using this pattern:
 
 ```bash
-copilot --model MODEL_NAME --allow-all-paths --allow-all-tools --log-level none -p "PROMPT_TEXT" 2>/dev/null
+copilot --model MODEL_NAME --log-level none -p "PROMPT_TEXT" 2>/dev/null
 ```
 
 Required flags:
 
-- `--allow-all-paths` - Allow access to all paths
-- `--allow-all-tools` - Allow all tool usage
 - `--log-level none` - Suppress log output
+
+Optional flags (add only when needed):
+
+- `--allow-all-paths` - Add when copilot needs to read files outside the current directory
+- `--allow-all-tools` - Add when copilot needs to execute commands or use external tools
+
+**Principle of least privilege:** Start without permission flags. Only add them if the task requires file access or tool execution.
 
 The command runs in the current working directory, providing copilot with the same context as Claude.
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -10,31 +10,7 @@ Issues identified during code review (2026-01-02).
 
 ## Medium
 
-### Broken deep-dive anchor links in quick-reference
-
-**Location:** `docs/rust-lessons/quick-reference.md` (lines 229, 257, 283, 307, 369, 398, 523, 552)
-
-**Description:** Multiple deep-dive links point to anchors that don't exist:
-- `performance-deep-dive.md#loop-optimizations` → should be `#1-performance-critical-loop-optimizations`
-- `performance-deep-dive.md#zero-copy` → should be `#2-when-not-to-use-zero-copy-abstractions`
-- `file-io-deep-dive.md#atomic-writes` → should be `#1-atomic-file-writes`
-- `file-io-deep-dive.md#parent-directories` → should be `#2-parent-directories-for-file-writes`
-- `file-io-deep-dive.md#testing` → should be `#4-testing-file-io`
-- `type-safety-deep-dive.md#constants` → should be `#2-using-constants-for-validation`
-- `common-footguns.md#borrow-checker` → should be `#3-borrow-checker-with-hashset`
-- `common-footguns.md#toctou-races` → should be `#4-fixing-toctou-races`
-
-**Fix:** Update links to match actual numbered heading anchors.
-
----
-
-### Overly permissive default flags in github-copilot skill
-
-**Location:** `.claude/skills/github-copilot/SKILL.md:37-48`
-
-**Description:** Default invocation recommends `--allow-all-paths --allow-all-tools` for every copilot call, granting unnecessary filesystem/tool access for simple second-opinion queries.
-
-**Fix:** Default to least privilege (omit flags unless required) and document when elevated access is needed.
+*No open issues.*
 
 ---
 

--- a/docs/rust-lessons/quick-reference.md
+++ b/docs/rust-lessons/quick-reference.md
@@ -226,7 +226,7 @@ for item in items {
 }
 ```
 
-📖 **[Full Guide: Performance →](performance-deep-dive.md#loop-optimizations)**
+📖 **[Full Guide: Performance →](performance-deep-dive.md#1-performance-critical-loop-optimizations)**
 
 ---
 
@@ -254,7 +254,7 @@ let keyword_lower = "hello".to_lowercase();
 text_lower.contains(&keyword_lower)
 ```
 
-📖 **[Full Guide: Performance →](performance-deep-dive.md#zero-copy)**
+📖 **[Full Guide: Performance →](performance-deep-dive.md#2-when-not-to-use-zero-copy-abstractions)**
 
 ---
 
@@ -280,7 +280,7 @@ temp.sync_all()?;
 temp.persist(final_path)?;  // Atomic rename
 ```
 
-📖 **[Full Guide: File I/O →](file-io-deep-dive.md#atomic-writes)**
+📖 **[Full Guide: File I/O →](file-io-deep-dive.md#1-atomic-file-writes)**
 
 ---
 
@@ -304,7 +304,7 @@ if let Some(parent) = path.parent() {
 fs::write(path, data)?;
 ```
 
-📖 **[Full Guide: File I/O →](file-io-deep-dive.md#parent-directories)**
+📖 **[Full Guide: File I/O →](file-io-deep-dive.md#2-parent-directory-creation)**
 
 ---
 
@@ -366,7 +366,7 @@ fn test_write_and_read_roundtrip() {
 }
 ```
 
-📖 **[Full Guide: File I/O →](file-io-deep-dive.md#testing)**
+📖 **[Full Guide: File I/O →](file-io-deep-dive.md#4-testing-file-io)**
 
 ---
 
@@ -395,7 +395,7 @@ if !VALID_EVENTS.contains(&event) {
 pub enum HookEvent { UserPromptSubmit, ... }
 ```
 
-📖 **[Full Guide: Type Safety →](type-safety-deep-dive.md#constants)**
+📖 **[Full Guide: Type Safety →](type-safety-deep-dive.md#2-using-constants-for-validation)**
 
 ---
 
@@ -519,7 +519,7 @@ for item in other.vec {
 }
 ```
 
-📖 **[Full Guide: Common Footguns →](common-footguns.md#borrow-checker)**
+📖 **[Full Guide: Common Footguns →](common-footguns.md#3-borrow-checker-with-hashset)**
 
 ---
 
@@ -549,7 +549,7 @@ match fs::read(path) {
 }
 ```
 
-📖 **[Full Guide: Common Footguns →](common-footguns.md#toctou-races)**
+📖 **[Full Guide: Common Footguns →](common-footguns.md#2-toctou-races)**
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix 8 broken deep-dive anchor links in quick-reference.md
- Apply principle of least privilege in github-copilot skill (remove default `--allow-all-paths --allow-all-tools` flags)

## Test plan

- [x] Verified all anchor links now match actual heading slugs
- [x] Confirmed github-copilot skill uses least privilege by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)