### PR TITLE
fix: correct lesson count in index.md

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -16,10 +16,4 @@ Issues identified during code review (2026-01-02).
 
 ## Low
 
-### Lesson count mismatch
-
-**Location:** `docs/rust-lessons/index.md:21-22` vs `docs/rust-lessons/quick-reference.md:12`
-
-**Description:** Index claims quick reference has 20 lessons, but quick-reference lists 21.
-
-**Fix:** Reconcile the counts or remove hard-coded numbers.
+*No open issues.*

--- a/docs/rust-lessons/index.md
+++ b/docs/rust-lessons/index.md
@@ -18,7 +18,7 @@ This directory contains Rust best practices and common mistakes discovered durin
 
 **[quick-reference.md](quick-reference.md)** - Scannable checklist of all rules
 
-- ~400 lines covering 20 lessons
+- ~700 lines covering 21 lessons
 - Each lesson: Rule + Quick check + 1 example + Link to deep dive
 - Perfect for code review or quick lookup
 - Can be scanned in under 2 minutes


### PR DESCRIPTION
## Summary

- Update lesson count from 20 to 21 in index.md to match quick-reference.md
- Also updated line count estimate (~400 → ~700)

## Test plan

- [x] Verified quick-reference.md has 21 numbered lessons (## 1 through ## 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)