### PR TITLE
docs: add agents contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+Purpose: Copilot CLI-focused challenge and documentation set for practicing workflows without Codex CLI.
+
+## Project Structure & Module Organization
+- Challenges grouped in `challenges/easy|medium|hard`; each file includes prompt, constraints, hints, and templates.
+- `docs/` contains onboarding (`GETTING_STARTED.md`), prompting/testing guidance (`BEST_PRACTICES.md`), and CLI comparison notes.
+- Skills for Copilot workflows live under `.claude/skills/`; this guide complements those instructions.
+
+## Build, Test, and Development Commands
+- No build pipeline here; work directly with Markdown challenges and docs.
+- Search quickly: `rg term challenges/medium` or list files with `rg --files`.
+- Word count check for docs: `wc -w AGENTS.md`.
+
+## Coding Style & Naming Conventions
+- Markdown: sentence-case headings, concise bullets, and fenced code blocks with language tags.
+- Challenge files follow the existing format (problem, examples, constraints, template, hints, approach, complexity).
+- Use descriptive names in code snippets to aid Copilot suggestions; keep indentation consistent with language defaults.
+
+## Testing Guidelines
+- Repository has no automated test suite; run sample snippets within challenge files or your language REPL.
+- If adding executable code or scripts, include inline assertions/examples and document how to run them.
+- Keep example inputs/outputs accurate and minimal.
+
+## Commit & Pull Request Guidelines
+- Follow observed prefixes (`docs:`, `chore:`) and keep messages imperative and scoped.
+- PRs should summarize changes, link issues when relevant, and include before/after details or screenshots for doc/format changes if helpful.
+- Update documentation when adding or modifying challenges.
+- When committing with Codex, add `Co-authored-by: ChatGPT (Codex CLI) <chatgpt@codex.cli>` so agent use is visible.
+
+## Security, Configuration, and Agent Notes
+- Do not include secrets, tokens, or proprietary problem statements in prompts or docs.
+- When using Copilot CLI, provide clear context but scrub sensitive data; prefer local files over pasted payloads.
+- Keep new files in the established directories; avoid creating new top-level folders without discussion.

--- a/docs/plans/2026-01-03-agents-guidelines.md
+++ b/docs/plans/2026-01-03-agents-guidelines.md
@@ -1,0 +1,57 @@
+# AGENTS Contributor Guide Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create `AGENTS.md` as a concise 200-400 word contributor guide titled "Repository Guidelines".
+
+**Architecture:** Single Markdown document at repo root with clear sections covering structure, commands, style, testing, commit/PR expectations, and security/agent tips tailored to this repo.
+
+**Tech Stack:** Markdown, Git.
+
+### Task 1: Confirm repo context
+
+**Files:**
+- Read: `README.md`, `challenges/README.md` (if present), `docs/GETTING_STARTED.md`, `docs/BEST_PRACTICES.md`, `docs/cli-coding-tools-comparison.md`
+
+**Step 1: Review current docs for expectations and terminology**
+
+Run: `ls challenges` and skim key docs above to ensure guidance matches existing patterns. Expected: identify difficulty folders and doc tone.
+
+### Task 2: Draft AGENTS.md outline
+
+**Files:**
+- Create: `AGENTS.md`
+
+**Step 1: Write headings and bullets**
+
+Include sections for project structure, build/test/dev commands, coding style/naming, testing guidelines, commit/PR rules, and security/config/agent tips. Keep wording concise and repo-specific.
+
+### Task 3: Fill content with repo specifics
+
+**Files:**
+- Modify: `AGENTS.md`
+
+**Step 1: Add structure details**
+
+Describe `challenges/<difficulty>`, `docs/`, and any skill references; include examples (e.g., `rg term challenges/medium`).
+
+**Step 2: Add command guidance**
+
+List key commands (e.g., `rg --files`, `wc -w AGENTS.md` for word count) and note no build/tests expected unless contributors add them.
+
+**Step 3: Add style, testing, and commit/PR conventions**
+
+Mirror observed commit prefixes (e.g., `docs:`) and markdown style expectations. Note PR requirements (summary, linked issues, screenshots when UI content).
+
+**Step 4: Add security/agent tips**
+
+Mention avoiding secrets in prompts/docs, and point to Copilot CLI usage guidance.
+
+### Task 4: Self-check
+
+**Files:**
+- Read: `AGENTS.md`
+
+**Step 1: Verify length and clarity**
+
+Run: `wc -w AGENTS.md` to confirm 200-400 words. Re-read for tone and section coverage. Expected: word count within range and sections clear.


### PR DESCRIPTION
## Summary
- add AGENTS.md contributor guide with structure/commands/style/testing guidance
- include commit/PR expectations and security/agent tips specific to Copilot CLI examples repo
- add implementation plan record under docs/plans

## Test Plan
- not run (docs-only change)

Co-authored-by: ChatGPT (Codex CLI)