### PR TITLE
Fix release workflow without lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
 
-      - name: Install semantic-release and plugins
+      - name: Install semantic-release
         run: |
           npm install --no-save \
             semantic-release \


### PR DESCRIPTION
- remove npm cache key that requires a lockfile (no package manager files in repo)\n- keep semantic-release install and execution for automatic releases on main\n\nTests: not run (workflow change)