### PR TITLE
Avoid git pushes in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,18 +4,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"]
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
- remove changelog/git plugins so semantic-release no longer pushes commits to main (blocked by branch rules)\n- keep commit analyzer, release-notes generator, and GitHub release/tag publishing\n\nTests: not run (workflow config)