### PR TITLE
Allow docs/chore commits to trigger releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,20 @@
   "branches": ["main"],
   "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "docs", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "build", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]


### PR DESCRIPTION
- configure commit-analyzer with conventional commits preset and release rules\n- docs/chore/refactor/style/test/build now trigger patch releases\n\nThis ensures docs updates produce releases per repo policy.\n\nTests: not run (config only)