### PR TITLE
Include docs/chore in release notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,7 +16,26 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "style", "section": "Style" },
+            { "type": "chore", "section": "Chores" },
+            { "type": "refactor", "section": "Refactoring" },
+            { "type": "test", "section": "Tests" },
+            { "type": "build", "section": "Build System" }
+          ]
+        }
+      }
+    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
- configure release-notes generator preset to show docs/chore/refactor/style/test/build sections\n- aligns release notes with commit types that trigger releases\n\nTests: not run (config only)