### PR TITLE
docs: fix Copilot CLI Windows support claim

### DIFF
--- a/docs/cli-coding-tools-comparison.md
+++ b/docs/cli-coding-tools-comparison.md
@@ -134,7 +134,7 @@ This comparison covers the three major AI-powered CLI coding agents based on the
 |---------|-------------|------------------|-------------------|
 | **macOS** | ✅ Full support | ✅ Full support | ✅ Full support |
 | **Linux** | ✅ Full support (incl. Alpine) | ✅ Full support | ✅ Full support |
-| **Windows** | ✅ Native + WSL | ✅ Native (improved in 5.2) | ✅ WSL only |
+| **Windows** | ✅ Native + WSL | ✅ Native (improved in 5.2) | ✅ Native + WSL |
 | **IDE Extension** | ✅ VS Code extension | ✅ VS Code/Cursor extension | ⚠️ Planned |
 
 ## Pricing & Access


### PR DESCRIPTION
## Summary
- Updates GitHub Copilot CLI Windows support from "WSL only" to "Native + WSL"
- Verified against official documentation confirming native Windows support via WinGet and npm (PowerShell v6+)

## Context
This fix was identified during a documentation review using web search verification and code reviews from both Codex (GPT-5.2) and Copilot (Gemini).

## Test plan
- [x] Verified claim against official GitHub Copilot CLI documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)